### PR TITLE
Added a ':' to allow name to be bound

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -10,7 +10,7 @@
 
         <div class="w-4/5 px-8 py-6">
             <vue-ckeditor
-                id="field.name"
+                :id="field.name"
                 v-model="value"
                 :config="config"
             />


### PR DESCRIPTION
Currently id of element was being hardcoded to the string 'field.name' this will allow multiple editors to work as desired