### PR TITLE
Add expandable trait so the detail view can collapse the content.

### DIFF
--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -1,7 +1,7 @@
 <template>
     <panel-item :field="field">
         <template slot="value">
-            <span v-html="field.value"></span>
+            <excerpt :content="field.value" :should-show="field.shouldShow"></excerpt>
         </template>
     </panel-item>
 </template>

--- a/src/NovaCkeditor.php
+++ b/src/NovaCkeditor.php
@@ -3,9 +3,12 @@
 namespace Waynestate\Nova;
 
 use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Fields\Expandable;
 
 class CKEditor extends Field
 {
+    use Expandable;
+
     /**
      * The field's component.
      *
@@ -34,6 +37,19 @@ class CKEditor extends Field
 
         return $this->withMeta([
             'options' => array_merge($currentOptions, $options),
+        ]);
+    }
+
+
+    /**
+     * Prepare the element for JSON serialization.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return array_merge(parent::jsonSerialize(), [
+            'shouldShow' => $this->shouldBeExpanded(),
         ]);
     }
 }


### PR DESCRIPTION
TextArea has the ability to add a "Show Content" button to hide long content from the detail view. This adds the same functionality to the CKEditor field.

<img width="585" alt="screen shot 2018-12-04 at 2 44 37 pm" src="https://user-images.githubusercontent.com/634788/49468591-4bff9000-f7d3-11e8-8833-0fb347889120.png">
