### PR TITLE
Add more documentation on how to change CKEditor instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ php artisan vendor:publish --tag=config --provider=Waynestate\\Nova\\CKEditorFie
 
 ## Customization
 
+### Configuration options
 You can change the [configuration options](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html) of the CKEditor instance by either editing the published config file at `nova.ckeditor-field.options`
 
 ```php
@@ -98,6 +99,11 @@ public function fields(Request $request)
     ];
 }
 ```
+
+### Custom CKEditor Instance
+If you wish to not use the CKEditor from the CKEditor CDN, you can change the `ckeditor_url` under `config/nova/ckeditor-field.php` to point to the URL of the CKEditor you wish to use.
+
+If you wish to go the route of a Custom CKEditor Instance using Composer then follow the steps at [Using Composer for Custom CKEditor Instance](https://github.com/waynestate/nova-ckeditor4-field/wiki/Using-Composer-for-Custom-CKEditor-Instance)
 
 ## Contributing
 

--- a/config/ckeditor-field.php
+++ b/config/ckeditor-field.php
@@ -10,6 +10,18 @@ return [
     |
     | Note: The URL must begin with "http://" or "https://"
     |
+    | If you wish to use a different CKEditor 4 preset you can use a
+    | CKEditor 4 preset from https://cdn.ckeditor.com/
+    |
+    | or
+    |
+    | you could use use composer to install your CKEditor from
+    | https://github.com/ckeditor/ckeditor-releases/ and symbolic link the
+    | "vendor/ckeditor/ckeditor" to "public/js/ckeditor".
+    | then replace the "ckeditor_url" to be
+    |
+    | 'ckeditor_url' => config('app.url').'/js/ckeditor/ckeditor.js',
+    |
     | CKEditor 4 is only supported. This will not work with CKEditor 5
     |
     */

--- a/config/ckeditor-field.php
+++ b/config/ckeditor-field.php
@@ -6,14 +6,14 @@ return [
     |--------------------------------------------------------------------------------
     |
     | This is the URL used to load the CKEditor instance.
-    | ex: https://cdn.ckeditor.com/4.10.1/standard-all/ckeditor.js
+    | ex: https://cdn.ckeditor.com/4.11.2/full-all/ckeditor.js
     |
     | Note: The URL must begin with "http://" or "https://"
     |
     | CKEditor 4 is only supported. This will not work with CKEditor 5
     |
     */
-    'ckeditor_url' => 'https://cdn.ckeditor.com/4.10.1/standard-all/ckeditor.js',
+    'ckeditor_url' => 'https://cdn.ckeditor.com/4.11.2/full-all/ckeditor.js',
 
     /*
     |--------------------------------------------------------------------------------


### PR DESCRIPTION
* Switched the default CKEditor instance to be `Full` instead of `Standard` and updated to [4.11.2](https://github.com/ckeditor/ckeditor-releases/blob/4.11.x/CHANGES.md#ckeditor-4112)
* Added new wiki with step by step list of how to set up a composer CKEditor instance

Fixes #5 