### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class Article extends Resource
 To change any of config values, publish a config file:
 
 ```bash
-php artisan vendor:publish --tag=config --provider=Waynestate\\Nova\\CKEditorFieldServiceProvider
+php artisan vendor:publish --tag=config --provider="Waynestate\Nova\CKEditorFieldServiceProvider"
 ```
 
 ## Customization


### PR DESCRIPTION
The correct syntax for the provider parameter is with double quotes.

This ensures that the command works on all operating systems (including Windows)