### PR TITLE
Fix saving of CKEditor field if using the default full plugin config that is loaded by CKEditor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waynestate/nova-ckeditor4-field",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "This nova package allows you to use CKEditor 4 for text areas.",
     "keywords": [
         "laravel",

--- a/src/CKEditor.php
+++ b/src/CKEditor.php
@@ -20,8 +20,10 @@ class CKEditor extends Field
     {
         parent::__construct($name, $attribute, $resolveCallback);
 
+        $defaultConfig = require __DIR__ . '/../config/ckeditor-field.php';
+
         $this->withMeta([
-            'options' => config('nova.ckeditor-field.options', [])
+            'options' => config('nova.ckeditor-field.options', $defaultConfig['options']),
         ]);
     }
 


### PR DESCRIPTION
Fixes #63 

If no configuration is provided for the options, then use the default CKEditor 4 field that is provided. It seems that something is conflicting with it.

Before:
<img width="1226" alt="Screen Shot 2022-07-25 at 5 36 21 PM" src="https://user-images.githubusercontent.com/636531/180878600-300f2646-e474-44d5-8f08-16946ddbcc86.png">

Nova CKEditor4 Default Options:
<img width="1206" alt="Screen Shot 2022-07-25 at 5 36 30 PM" src="https://user-images.githubusercontent.com/636531/180878617-2c35716c-52da-4b4e-9217-2c27ecdd94da.png">

