### PR TITLE
Keep custom config when file upload is enabled

### DIFF
--- a/src/CKEditor.php
+++ b/src/CKEditor.php
@@ -118,16 +118,12 @@ class CKEditor extends Trix
                 $extraPlugins[] = 'uploadimage';
             }
 
-            $this->withMeta([
-                'options' => [
-                    'extraPlugins' => implode(',', $extraPlugins),
-                ],
+            $this->options([
+                'extraPlugins' => implode(',', $extraPlugins),
             ]);
         } else {
-            $this->withMeta([
-                'options' => [
-                    'extraPlugins' => 'uploadimage',
-                ],
+            $this->options([
+                'extraPlugins' => 'uploadimage',
             ]);
         }
     }


### PR DESCRIPTION
Hi,
When using file upload, the custom configuration is lost because the `options` is purely replaced.
Thanks a lot for your package, it's pretty tough to find a full featured Nova rich text editor!
Regards,
Karel