### PR TITLE
Ignore creating tables, if they already exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-* Removed badges except the download since it seems to be only one working
+## [1.1.4] - 2022-11-02
+### Fixed
+* Add check for migrations to make sure the table doesn't exist before trying to create it. by @chrispelzer in https://github.com/waynestate/nova-ckeditor4-field/pull/68 https://github.com/waynestate/nova-ckeditor4-field/issues/67
 
 ## [1.1.3] - 2022-10-13
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Laravel Nova CKEditor 4 Field
- 
-[![Daily Downloads](http://poser.pugx.org/waynestate/nova-ckeditor4-field/d/daily)](https://packagist.org/packages/waynestate/nova-ckeditor4-field)
+
+[![Latest Stable Version](http://poser.pugx.org/waynestate/nova-ckeditor4-field/v)](https://packagist.org/packages/waynestate/nova-ckeditor4-field) [![Daily Downloads](http://poser.pugx.org/waynestate/nova-ckeditor4-field/d/daily)](https://packagist.org/packages/waynestate/nova-ckeditor4-field)
+[![Total Downloads](http://poser.pugx.org/waynestate/nova-ckeditor4-field/downloads)](https://packagist.org/packages/waynestate/nova-ckeditor4-field) [![Latest Unstable Version](http://poser.pugx.org/waynestate/nova-ckeditor4-field/v/unstable)](https://packagist.org/packages/waynestate/nova-ckeditor4-field) [![License](http://poser.pugx.org/waynestate/nova-ckeditor4-field/license)](https://packagist.org/packages/waynestate/nova-ckeditor4-field) [![PHP Version Require](http://poser.pugx.org/waynestate/nova-ckeditor4-field/require/php)](https://packagist.org/packages/waynestate/nova-ckeditor4-field) 
 
 This nova package allows you to use [CKEditor 4](https://ckeditor.com/ckeditor-4/) for text areas using Nova v4.
 

--- a/database/migrations/create_ckeditor_attachment_tables.php
+++ b/database/migrations/create_ckeditor_attachment_tables.php
@@ -12,25 +12,29 @@ return new class extends Migration {
      */
     public function up()
     {
-        Schema::create('nova_pending_ckeditor_attachments', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('draft_id')->index();
-            $table->string('attachment');
-            $table->string('disk');
-            $table->timestamps();
-        });
+        if (!Schema::hasTable('nova_pending_ckeditor_attachments')) {
+            Schema::create('nova_pending_ckeditor_attachments', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('draft_id')->index();
+                $table->string('attachment');
+                $table->string('disk');
+                $table->timestamps();
+            });
+        }
 
-        Schema::create('nova_ckeditor_attachments', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('attachable_type');
-            $table->unsignedInteger('attachable_id');
-            $table->string('attachment');
-            $table->string('disk');
-            $table->string('url')->index();
-            $table->timestamps();
+        if (!Schema::hasTable('nova_ckeditor_attachments')) {
+            Schema::create('nova_ckeditor_attachments', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('attachable_type');
+                $table->unsignedInteger('attachable_id');
+                $table->string('attachment');
+                $table->string('disk');
+                $table->string('url')->index();
+                $table->timestamps();
 
-            $table->index(['attachable_type', 'attachable_id']);
-        });
+                $table->index(['attachable_type', 'attachable_id']);
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Wrap the creates with `hasTable` to make sure they don't exist before trying to create them, otherwise it will error if tables are created outside migrations with no way of avoiding previously

Fixes #67 