### PR TITLE
update CKEditor default URL from 4.20.0 to 4.20.2

### DIFF
--- a/config/ckeditor-field.php
+++ b/config/ckeditor-field.php
@@ -84,5 +84,5 @@ return [
     | CKEditor 4 is only supported. This will not work with CKEditor 5
     |
     */
-    'ckeditor_url' => 'https://cdn.ckeditor.com/4.20.0/full-all/ckeditor.js',
+    'ckeditor_url' => 'https://cdn.ckeditor.com/4.20.2/full-all/ckeditor.js',
 ];


### PR DESCRIPTION
Latest patch version of CKEditor v4.20.2
https://cdn.ckeditor.com/