### PR TITLE
Set image2 within the extraplugins if it isn't present.

### DIFF
--- a/src/CKEditor.php
+++ b/src/CKEditor.php
@@ -118,12 +118,16 @@ class CKEditor extends Trix
                 $extraPlugins[] = 'uploadimage';
             }
 
+            if (!in_array('image2', $extraPlugins)) {
+                $extraPlugins[] = 'image2';
+            }
+
             $this->options([
                 'extraPlugins' => implode(',', $extraPlugins),
             ]);
         } else {
             $this->options([
-                'extraPlugins' => 'uploadimage',
+                'extraPlugins' => 'image2,uploadimage',
             ]);
         }
     }


### PR DESCRIPTION
When there is no user configuration present and `->withFiles()` option is used, the image2 plugin wasn't being inserted with the uploadimage. This will now make image2 properly used.

https://github.com/waynestate/nova-ckeditor4-field/discussions/80