### PR TITLE
Fix merging of options to prevent combining if the same key exists within the merging arrays

### DIFF
--- a/src/CKEditor.php
+++ b/src/CKEditor.php
@@ -43,7 +43,7 @@ class CKEditor extends Trix
         $currentOptions = $this->meta['options'] ?? [];
 
         return $this->withMeta([
-            'options' => array_merge_recursive($currentOptions, $options),
+            'options' => array_merge($currentOptions, $options),
         ]);
     }
 


### PR DESCRIPTION
recursive on the options merge isn't needed as it would look merged the same keys rather than replace the keys if they exist.

Closes #87 