### PR TITLE
fix: disable version check

### DIFF
--- a/config/ckeditor-field.php
+++ b/config/ckeditor-field.php
@@ -24,6 +24,7 @@ return [
             ['Format', 'FontSize'],
             ['Maximize', 'ShowBlocks', '-', 'About'],
         ],
+        'versionCheck' => false,
     ],
 
     /*


### PR DESCRIPTION
Fixes (kinda) https://github.com/waynestate/nova-ckeditor4-field/issues/95.

CKEditor 4 is not free anymore and requires paid "Extended Support Model" to make it working ([see reference](https://ckeditor.com/ckeditor-4/)) with license key.