### PR TITLE
Update fillAttribute to return parent result by default

### DIFF
--- a/src/CKEditor.php
+++ b/src/CKEditor.php
@@ -92,7 +92,7 @@ class CKEditor extends Trix
      */
     protected function fillAttribute(NovaRequest $request, $requestAttribute, $model, $attribute): ?callable
     {
-        parent::fillAttribute($request, $requestAttribute, $model, $attribute);
+        $result = parent::fillAttribute($request, $requestAttribute, $model, $attribute);
 
         if ($request->{$this->attribute.'DraftId'} && $this->withFiles) {
             return function () use ($request, $model, $attribute) {
@@ -103,6 +103,8 @@ class CKEditor extends Trix
                 );
             };
         }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
After upgrading to v2.0.0 I was getting the following error when trying to save a resource that included a CKEditor field

```
Waynestate\Nova\CKEditor4Field\CKEditor::fillAttribute(): Return value must be of type ?callable, none returned
```

It looks like this was caused by the addition of the return type. If there is no pending upload, then the method does not return, which is apparently a type error.

Being completely honest, I am not sure on the ramifications of my suggested change. I initially changed it to just return `null`, which fixed the error for me. Then I changed it to return the result of `parent::fillAttribute()`, which also works for me. 

Where my uncertainty comes in is when there are uploads to handle. We do not use the upload functionality so I can't easily test to make sure that still works as expected. Would be great if someone who does have it setup to do uploads could give this a test to make sure it works for them still.